### PR TITLE
Update Bundler version from 2.0.2 to 2.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,4 +24,4 @@ DEPENDENCIES
   graphql-client
 
 BUNDLED WITH
-   2.0.2
+   2.7.2


### PR DESCRIPTION
## problem

oss-contributions workflow doesn't work with Ruby 3.4.7 (latest).

```
$ bundle
Bundler 2.7.2 is running, but your lockfile was generated with 2.0.2. Installing Bundler 2.0.2 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.0.2
Installing bundler 2.0.2
/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/error.rb:109:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/error.rb:1:in '<top (required)>'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:4:in '<top (required)>'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:2:in '<top (required)>'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:5:in '<top (required)>'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from <internal:/Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.0.2/exe/bundle:21:in '<top (required)>'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/bin/bundle:25:in 'Kernel#load'
        from /Users/hogashi/.anyenv/envs/rbenv/versions/3.4.7/bin/bundle:25:in '<main>'
```

It seems that is because of the bundler which uses old version of thor.

- same issue https://github.com/rails/thor/issues/895
- fixed pull req https://github.com/rails/thor/pull/637
  - released in 0.20.3 https://github.com/rails/thor/releases/tag/v0.20.3

## what I did

I upgraded bundler version written in Gemfile.lock to the latest version of bundler https://rubygems.org/gems/bundler/versions/2.7.2 and it is resolved (I'm not sure if bundler 2.0.2 uses thor 0.20.3.)

```
$ bundle
Fetching gem metadata from https://rubygems.org/............
Fetching concurrent-ruby 1.1.10
Fetching minitest 5.16.2
Fetching graphql 1.11.2
Installing concurrent-ruby 1.1.10
Installing minitest 5.16.2
Fetching i18n 1.12.0
Fetching tzinfo 2.0.5
Installing graphql 1.11.2
Installing i18n 1.12.0
Installing tzinfo 2.0.5
Fetching activesupport 7.0.3.1
Installing activesupport 7.0.3.1
Fetching graphql-client 0.16.0
Installing graphql-client 0.16.0
Bundle complete! 1 Gemfile dependency, 8 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```
